### PR TITLE
Fix end of history error

### DIFF
--- a/finito-view.el
+++ b/finito-view.el
@@ -105,7 +105,9 @@
 If OBJ has an empty value and `finito-save-last-search' is non-nil, switch
 to the last value used for OBJ."
   (transient--history-init obj)
-  (when (and finito-save-last-search (oref obj value))
+  (when (and finito-save-last-search
+             (not (oref obj value))
+             (cdr (oref obj history)))
     (let ((transient--prefix obj))
       (transient-history-prev))))
 

--- a/finito-view.el
+++ b/finito-view.el
@@ -105,7 +105,7 @@
 If OBJ has an empty value and `finito-save-last-search' is non-nil, switch
 to the last value used for OBJ."
   (transient--history-init obj)
-  (when (and finito-save-last-search (not (oref obj value)))
+  (when (and finito-save-last-search (oref obj value))
     (let ((transient--prefix obj))
       (transient-history-prev))))
 


### PR DESCRIPTION
There won't be any searches made initially so users will encounter
`End of history` transient error because of ~~negated check~~ when they
try to use `(finito-search)`